### PR TITLE
remove the section for checking live space

### DIFF
--- a/manifest/operations/pipelines/cf-apps-es.yml
+++ b/manifest/operations/pipelines/cf-apps-es.yml
@@ -300,21 +300,6 @@
                     }
                 }
             }
-          
-            if [rtr][hostname] =~ /^.*dev\.cf\.springer-sbm\.com$/ {
-              mutate {
-                add_field => {
-                  "[@cf][onprem]" => "dev"
-                }
-              }
-            }
-            else {
-              mutate {
-                add_field => {
-                  "[@cf][onprem]" => "live"
-                }
-              }
-            }
           }
           
         filter-52-api-logmessages: |

--- a/manifest/operations/pipelines/cf-apps-es/filter-50-rtr-logmessages.conf
+++ b/manifest/operations/pipelines/cf-apps-es/filter-50-rtr-logmessages.conf
@@ -66,20 +66,5 @@ filter {
           }
       }
   }
-
-  if [rtr][hostname] =~ /^.*dev\.cf\.springer-sbm\.com$/ {
-    mutate {
-      add_field => {
-        "[@cf][onprem]" => "dev"
-      }
-    }
-  }
-  else {
-    mutate {
-      add_field => {
-        "[@cf][onprem]" => "live"
-      }
-    }
-  }
 }
 


### PR DESCRIPTION
I dont think we need to have addtional field "dev" for the messages which is not coming from live. Because we have a field `[cf][space]` which tells if the log is coming from live, test, dev etc. So in order to see all the logs that do not belong to live we can just query in kibana `[cf][space] is not live`. This should achieve the goal of knowing all the logs that is not production from onprem.